### PR TITLE
feat: remove price field from readonly

### DIFF
--- a/reservation/admin.py
+++ b/reservation/admin.py
@@ -3,7 +3,7 @@ from reservation.models import Reservation
 
 
 class Reservations(admin.ModelAdmin):
-    readonly_fields = ('cod_reservation', 'price')
+    readonly_fields = ('cod_reservation',)
     list_display = ('id', 'cod_reservation', 'advertisement',
                     'price', 'check_in_date', 'check_out_date')
 

--- a/reservation/api/factory/reservation_factory.py
+++ b/reservation/api/factory/reservation_factory.py
@@ -1,3 +1,4 @@
+from factory import Sequence
 import factory
 from factory import Faker
 from reservation.models import Reservation
@@ -8,6 +9,7 @@ class ReservationFactory(factory.django.DjangoModelFactory):
     class Meta:
         model = Reservation
 
+    cod_reservation = Sequence(lambda n: f"PRT00{n}")
     advertisement = factory.SubFactory(AdvertisementFactory)
     check_in_date = '2023-09-20'
     check_out_date = '2023-10-20'

--- a/reservation/api/serializer.py
+++ b/reservation/api/serializer.py
@@ -6,6 +6,7 @@ class ReservationSerializers(serializers.ModelSerializer):
     class Meta:
         model = Reservation
         fields = '__all__'
+        read_only_fields = ['cod_reservation']
 
     def validate(self, data):
         check_in_date = data.get('check_in_date')

--- a/reservation/models.py
+++ b/reservation/models.py
@@ -17,10 +17,6 @@ class Reservation(models.Model):
         return f'{self.pk}'
 
     def save(self, *args, **kwargs):
-        # cleaning_fee = self.advertisement.property.cleaning_fee
-        # plataform_fee = self.advertisement.platform_fee
-        # result_days = self.check_out_date - self.check_in_date
-        # self.price = (cleaning_fee + (plataform_fee * 100) / 100) * result_days
         if not self.cod_reservation:
             last_reservation = Reservation.objects.order_by(
                 '-cod_reservation').first()


### PR DESCRIPTION
## Context

1.  Remove price field from `readonly_fields` in [admin](https://github.com/MarinaSpadetto/seazone/blob/f6b3faf461a7fdd8edfda9be0736efe668e9bcd7/reservation/admin.py#L6)
2. Add `cod_reservation` in [ReservationFactory](https://github.com/MarinaSpadetto/seazone/blob/f6b3faf461a7fdd8edfda9be0736efe668e9bcd7/reservation/api/factory/reservation_factory.py#L12)
3. Add `cod_reservation` in `read_only_fields` [ReservationSerializers](https://github.com/MarinaSpadetto/seazone/blob/f6b3faf461a7fdd8edfda9be0736efe668e9bcd7/reservation/api/serializer.py#L9)
4. Remove comments in [ReservationModel](https://github.com/MarinaSpadetto/seazone/blob/f6b3faf461a7fdd8edfda9be0736efe668e9bcd7/reservation/models.py#L20).